### PR TITLE
[IOS-1540] - Add accessibility_id for each date in calendar

### DIFF
--- a/MNCalendarView/MNCalendarView.m
+++ b/MNCalendarView/MNCalendarView.m
@@ -24,7 +24,7 @@
 @property(nonatomic,assign,readwrite) NSUInteger daysInWeek;
 
 @property(nonatomic,strong,readwrite) NSDateFormatter *monthFormatter;
-@property(nonatomic,strong,readonly) NSDateFormatter *accessibilityDateFormatter;
+@property(nonatomic,strong) NSDateFormatter *accessibilityDateFormatter;
 
 - (NSDate *)firstVisibleDateOfMonth:(NSDate *)date;
 - (NSDate *)lastVisibleDateOfMonth:(NSDate *)date;

--- a/MNCalendarView/MNCalendarView.m
+++ b/MNCalendarView/MNCalendarView.m
@@ -24,6 +24,7 @@
 @property(nonatomic,assign,readwrite) NSUInteger daysInWeek;
 
 @property(nonatomic,strong,readwrite) NSDateFormatter *monthFormatter;
+@property(nonatomic,strong,readonly) NSDateFormatter *accessibilityDateFormatter;
 
 - (NSDate *)firstVisibleDateOfMonth:(NSDate *)date;
 - (NSDate *)lastVisibleDateOfMonth:(NSDate *)date;
@@ -53,10 +54,18 @@
     _dateBackgroundColor = [UIColor whiteColor];
     _dateTextColor = [UIColor darkTextColor];
     
+    _accessibilityDateFormatter = [self iso8601DateFormatter];
     
     [self addSubview:self.collectionView];
     [self applyConstraints];
     [self reloadData];
+}
+
+- (NSDateFormatter *)iso8601DateFormatter {
+    NSDateFormatter *dateFormatter = [NSDateFormatter new];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd"];
+    [dateFormatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar]];
+    return dateFormatter;
 }
 
 - (id)initWithFrame:(CGRect)frame {
@@ -318,6 +327,8 @@
             month:monthDate
          calendar:self.calendar];
     
+    [cell.titleLabel setAccessibilityIdentifier:[_accessibilityDateFormatter stringFromDate:date]];
+
     [cell setToday:NO];
     
     BOOL isEnable = cell.enabled;

--- a/MNCalendarView/MNCalendarViewDayCell.m
+++ b/MNCalendarView/MNCalendarViewDayCell.m
@@ -45,26 +45,23 @@ NSString *const MNCalendarViewDayCellIdentifier = @"MNCalendarViewDayCellIdentif
     _disableTextBackgroundColor = [UIColor colorWithRed:.96f green:.96f blue:.96f alpha:1.f];
 }
 
-- (void)setDate:(NSDate *)date
-          month:(NSDate *)month
-       calendar:(NSCalendar *)calendar {
+- (void)setDate:(NSDate *)date month:(NSDate *)month calendar:(NSCalendar *)calendar {
     
     self.date     = date;
     self.month    = month;
     self.calendar = calendar;
     
-    NSDateComponents *components =
-    [self.calendar components:NSMonthCalendarUnit|NSDayCalendarUnit|NSWeekdayCalendarUnit
-                     fromDate:self.date];
+    NSDateComponents *components = [self.calendar components:NSMonthCalendarUnit|NSDayCalendarUnit|NSWeekdayCalendarUnit
+                                                    fromDate:self.date];
     
-    NSDateComponents *monthComponents =
-    [self.calendar components:NSMonthCalendarUnit
-                     fromDate:self.month];
+    NSDateComponents *monthComponents = [self.calendar components:NSMonthCalendarUnit
+                                                         fromDate:self.month];
     
     self.weekday = components.weekday;
     self.titleLabel.text = [NSString stringWithFormat:@"%d", components.day];
     self.titleLabel.userInteractionEnabled = YES; // TODO: hack to work
     self.titleLabel.accessibilityLabel = [NSString stringWithFormat:@"%d/%d", components.day, components.month]; // TODO
+    self.titleLabel.accessibilityIdentifier = [self iso8601withoutTimeStringFromDate:date];
     self.enabled = monthComponents.month == components.month;
     
     [self setNeedsDisplay];
@@ -132,6 +129,13 @@ NSString *const MNCalendarViewDayCellIdentifier = @"MNCalendarViewDayCellIdentif
 - (CGRect)circleFrame {
     CGRect rect = self.bounds;
     return CGRectInset(rect, 5, 5);
+}
+
+- (NSString *)iso8601withoutTimeStringFromDate:(NSDate *)date {
+    NSDateFormatter *dateformatter = [NSDateFormatter new];
+    [dateformatter setDateFormat:@"yyyy-MM-dd"];
+    [dateformatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar]];
+    return [dateformatter stringFromDate:date];
 }
 
 @end

--- a/MNCalendarView/MNCalendarViewDayCell.m
+++ b/MNCalendarView/MNCalendarViewDayCell.m
@@ -61,7 +61,6 @@ NSString *const MNCalendarViewDayCellIdentifier = @"MNCalendarViewDayCellIdentif
     self.titleLabel.text = [NSString stringWithFormat:@"%d", components.day];
     self.titleLabel.userInteractionEnabled = YES; // TODO: hack to work
     self.titleLabel.accessibilityLabel = [NSString stringWithFormat:@"%d/%d", components.day, components.month]; // TODO
-    self.titleLabel.accessibilityIdentifier = [self iso8601withoutTimeStringFromDate:date];
     self.enabled = monthComponents.month == components.month;
     
     [self setNeedsDisplay];
@@ -129,13 +128,6 @@ NSString *const MNCalendarViewDayCellIdentifier = @"MNCalendarViewDayCellIdentif
 - (CGRect)circleFrame {
     CGRect rect = self.bounds;
     return CGRectInset(rect, 5, 5);
-}
-
-- (NSString *)iso8601withoutTimeStringFromDate:(NSDate *)date {
-    NSDateFormatter *dateformatter = [NSDateFormatter new];
-    [dateformatter setDateFormat:@"yyyy-MM-dd"];
-    [dateformatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar]];
-    return [dateformatter stringFromDate:date];
 }
 
 @end

--- a/MNCalendarView/MNCalendarViewDayCell.m
+++ b/MNCalendarView/MNCalendarViewDayCell.m
@@ -45,17 +45,21 @@ NSString *const MNCalendarViewDayCellIdentifier = @"MNCalendarViewDayCellIdentif
     _disableTextBackgroundColor = [UIColor colorWithRed:.96f green:.96f blue:.96f alpha:1.f];
 }
 
-- (void)setDate:(NSDate *)date month:(NSDate *)month calendar:(NSCalendar *)calendar {
+- (void)setDate:(NSDate *)date
+          month:(NSDate *)month
+       calendar:(NSCalendar *)calendar {
     
     self.date     = date;
     self.month    = month;
     self.calendar = calendar;
     
-    NSDateComponents *components = [self.calendar components:NSMonthCalendarUnit|NSDayCalendarUnit|NSWeekdayCalendarUnit
-                                                    fromDate:self.date];
+    NSDateComponents *components =
+    [self.calendar components:NSMonthCalendarUnit|NSDayCalendarUnit|NSWeekdayCalendarUnit
+                     fromDate:self.date];
     
-    NSDateComponents *monthComponents = [self.calendar components:NSMonthCalendarUnit
-                                                         fromDate:self.month];
+    NSDateComponents *monthComponents =
+    [self.calendar components:NSMonthCalendarUnit
+                     fromDate:self.month];
     
     self.weekday = components.weekday;
     self.titleLabel.text = [NSString stringWithFormat:@"%d", components.day];


### PR DESCRIPTION
- JIRA: http://jira.redplanethotels.com:8080/browse/IOS-1540

As we are implementing UITests for booking flow. 

But MNCalendarView doesn't have Accessibility_Identifier for each date. So Accessibility_Identifier need to be define to select specific booking date.

I set `accessibility_id` to `UILabel` with date to string with format `yyyy-MM-dd`. I tried to set to `UICollectionViewCell` but it's not working. Because `UILabel` is on top layer and on size is equal to Cell

and in ruby side `Date` class `.to_s` return in this format, so it's easy to implement in ruby client side.


![screen shot 2561-02-01 at 3 33 27 pm](https://user-images.githubusercontent.com/6483170/35668760-47f62550-0765-11e8-9d79-c69ea78919c3.png)

 
![screen shot 2561-02-01 at 3 31 36 pm](https://user-images.githubusercontent.com/6483170/35668691-05f77186-0765-11e8-95ff-17301c985f36.png)
