### PR TITLE
Custom view cell identifier

### DIFF
--- a/MNCalendarView/MNCalendarView.m
+++ b/MNCalendarView/MNCalendarView.m
@@ -365,14 +365,6 @@
         }
         [cell setEnabled:[self dateEnabled:date]];
     }
-
-    if (cell.enabled) {
-        NSString *identifier = [NSString stringWithFormat:@"%@.%@",
-                                _accessibilityDomain,
-                                [_accessibilityDateFormatter stringFromDate:date]];
-        [cell setAccessibilityIdentifier:identifier];
-        [cell setAccessibilityLabel:identifier];
-    }
     
     [cell setSelected:NO];
     [cell setHighlighted:NO];
@@ -393,6 +385,17 @@
             [date compare:self.endDate] == NSOrderedAscending) {
             [cell setHighlighted:YES];
         }
+    }
+
+    if (cell.enabled) {
+        NSString *identifier = [NSString stringWithFormat:@"%@.%@",
+                                _accessibilityDomain,
+                                [_accessibilityDateFormatter stringFromDate:date]];
+        [cell setAccessibilityIdentifier:identifier];
+        [cell setAccessibilityLabel:identifier];
+    } else {
+        [cell setAccessibilityIdentifier:nil];
+        [cell setAccessibilityLabel:nil];
     }
 
     return cell;


### PR DESCRIPTION
Because table view cells are reusable, so I met a problem if we don't clear the identifier in case it is disabled
- Add identifier for cell if it is enabled
- Remove identifier if it is disabled
